### PR TITLE
fixed AttributeError in JsonLoader by correctly initializing path att…

### DIFF
--- a/src/pytest_bdd_report/interfaces.py
+++ b/src/pytest_bdd_report/interfaces.py
@@ -16,14 +16,9 @@ class ISummary(Protocol):
 
 
 class ILoader(Protocol):
-    def __init__(self, path: str):
-        self.path = path
+    path: str  # For type checking, indicating implementing classes should have this attribute
 
     def load(self) -> list[dict]:
-        """
-        Load the data from the path passed in the constructor.
-        @return: data as a list of dictionary
-        """
         ...
 
 

--- a/src/pytest_bdd_report/json_loader.py
+++ b/src/pytest_bdd_report/json_loader.py
@@ -6,7 +6,7 @@ from pytest_bdd_report.interfaces import ILoader
 
 class JsonLoader(ILoader):
     def __init__(self, path: str):
-        super().__init__(path)
+        self.path = path
 
     def load(self) -> list[dict]:
         if os.path.exists(self.path):


### PR DESCRIPTION
**Issue:**
It was attempting to initialize an instance attribute in the constructor of a Protocol, which is not supported by Python's typing system. This led to runtime error "AttributeError" when the attribute was accessed
**Solution**
Removed the constructor from the protocol. Implemented the attribute initialization in the concrete class `JsonLoader` which aligns to Python's runtime behavior and static typing system 


**Error Message**
```
[gw0] FAILED tests/step_definition/Workspace/test_PHNX-3195.py::test_a_long_list_of_workspaces <- ../../home/user/.local/lib/python3.10/site-packages/pytest_bdd/scenario.py Traceback (most recent call last):
  File "/home/user/.local/bin/pytest", line 8, in <module>
    sys.exit(console_main())
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/config/__init__.py", line 197, in console_main
    code = main()
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/config/__init__.py", line 174, in main
    ret: Union[ExitCode, int] = config.hook.pytest_cmdline_main(
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/main.py", line 319, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/main.py", line 307, in wrap_session
    config.hook.pytest_sessionfinish(
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_hooks.py", line 501, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 138, in _multicall
    raise exception.with_traceback(exception.__traceback__)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/logging.py", line 861, in pytest_sessionfinish
    return (yield)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/terminal.py", line 854, in pytest_sessionfinish
    result = yield
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 121, in _multicall
    teardown.throw(exception)  # type: ignore[union-attr]
  File "/home/user/.local/lib/python3.10/site-packages/_pytest/warnings.py", line 138, in pytest_sessionfinish
    return (yield)
  File "/home/user/.local/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/home/user/.local/lib/python3.10/site-packages/pytest_bdd_report/pytest_bdd_report.py", line 71, in pytest_sessionfinish
    report_generator = ReportComposer(
  File "/home/user/.local/lib/python3.10/site-packages/pytest_bdd_report/report_composer.py", line 7, in __init__
    self.data: list[dict] = loader.load()
  File "/home/user/.local/lib/python3.10/site-packages/pytest_bdd_report/json_loader.py", line 12, in load
    if os.path.exists(self.path):
AttributeError: 'JsonLoader' object has no attribute 'path'
```