### PR TITLE
Set encoding to utf-8 during file opening

### DIFF
--- a/src/pytest_bdd_report/extractor.py
+++ b/src/pytest_bdd_report/extractor.py
@@ -94,7 +94,7 @@ class FeatureExtractor(BaseExtractor):
     @staticmethod
     def _check_for_skipped_scenarios(feature: Feature) -> int:
         try:
-            with open(os.path.abspath(feature.uri), "r") as f:
+            with open(os.path.abspath(feature.uri), "r", encoding="utf-8") as f:
                 lines = f.readlines()
 
             if not lines:

--- a/src/pytest_bdd_report/json_loader.py
+++ b/src/pytest_bdd_report/json_loader.py
@@ -10,7 +10,7 @@ class JsonLoader(ILoader):
 
     def load(self) -> list[dict]:
         if os.path.exists(self.path):
-            with open(self.path, "r") as f:
+            with open(self.path, "r", encoding="utf-8") as f:
                 return json.load(f)
         else:
             return []

--- a/src/pytest_bdd_report/pytest_bdd_report.py
+++ b/src/pytest_bdd_report/pytest_bdd_report.py
@@ -57,7 +57,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     """
     bdd_report_flag = _get_flag_option(config, BDD_REPORT_FLAG)
     if bdd_report_flag != ".html":
-        print(f"\n\n📈 Report created at: {bdd_report_flag}")
+        print(f"\n\n Report created at: {bdd_report_flag}")
 
 
 @pytest.hookimpl(trylast=True)

--- a/src/pytest_bdd_report/report_file_generator.py
+++ b/src/pytest_bdd_report/report_file_generator.py
@@ -82,5 +82,5 @@ class ReportFileGenerator:
         if "/" in path:
             os.makedirs(os.path.dirname(path), exist_ok=True)
 
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(self.report_content)


### PR DESCRIPTION
Without setting the encoding to uft-8 the html file is not created properly and the browser shows a blank page.
Only setting the html writer to utf-8
![image](https://github.com/user-attachments/assets/01063750-6419-4013-a366-200f713f5048)
With all the changes:
![image](https://github.com/user-attachments/assets/4094b2b7-57a3-44e5-8957-37c691dd917b)

Removed 📈 as it threw errors when trying to run it on my windows pc.