### PR TITLE
Update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
 	'pytest >= 7.1.3',
-	'pytest-bdd >= 5.0.0,<7.0.0',
+	'pytest-bdd >= 5.0.0,<9.0.0',
 	'Jinja2 >= 3.1.2',
 ]
 


### PR DESCRIPTION
The plugin does not work with the latest `pytest-bdd`, however it is compatible.